### PR TITLE
#3095 S3 objects are deleted with parent resource

### DIFF
--- a/ckanext/cloudstorage/plugin.py
+++ b/ckanext/cloudstorage/plugin.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from ckan import plugins
 from routes.mapper import SubMapper
-
+import os.path
 from ckanext.cloudstorage import storage
 
 
@@ -10,6 +10,7 @@ class CloudStoragePlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IUploader)
     plugins.implements(plugins.IRoutes, inherit=True)
     plugins.implements(plugins.IConfigurable)
+    plugins.implements(plugins.IResourceController, inherit=True)
 
     def configure(self, config):
         required_keys = (
@@ -56,3 +57,41 @@ class CloudStoragePlugin(plugins.SingletonPlugin):
             )
 
         return map
+
+    # IResourceController
+
+    def before_delete(self, context, resource, resources):
+        # let's get all info about our resource. It somewhere in resources
+        # but if there is some possibility that it isn't(magic?) we have
+        # `else` clause
+
+        for res in resources:
+            if res['id'] == resource['id']:
+                break
+        else:
+            return
+        # just ignore simple links
+        if res['url_type'] != 'upload':
+            return
+
+        # we don't want to change original item from resources, just in case
+        # someone will use it in another `before_delete`. So, let's copy it
+        # and add `clear_upload` flag
+        res_dict = dict(res.items() + [('clear_upload', True)])
+
+        uploader = self.get_resource_uploader(res_dict)
+
+        # to be on the safe side, let's check existence of container
+        container = getattr(uploader, 'container', None)
+        if container is None:
+            return
+
+        # and now uploader removes our file.
+        uploader.upload(resource['id'])
+
+        # and all other files linked to this resource
+        if not uploader.leave_files:
+            upload_path = os.path.dirname(uploader.path_from_filename(resource['id'], 'fake-name'))
+            for old_file in uploader.container.iterate_objects():
+                if old_file.name.startswith(upload_path):
+                    old_file.delete()


### PR DESCRIPTION
Possible solution for [#3095](https://github.com/ckan/ckan/issues/3095) issue.

Implemented using IResourceController::before_delete

When resource deleted, initiates uploader's `upload` action with `clear_upload` field set to True. As result, file removed from cloud. 
In addition, if uploader::leave_files is False(default value), iterates over all previously uploaded files and removes them as well.