### PR TITLE
Encode filename as uricomponent during multipart upload

### DIFF
--- a/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
+++ b/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
@@ -324,7 +324,7 @@ ckan.module('cloudstorage-multipart-upload', function($, _) {
                 url: this.sandbox.client.url('/api/action/cloudstorage_initiate_multipart'),
                 data: JSON.stringify({
                     id: id,
-                    name: file.name,
+                    name: encodeURIComponent(file.name),
                     size: file.size
                 })
             });


### PR DESCRIPTION
Issue:
receiving `Bad Action API request data` error inside `initiate_multipart_upload` if filename contains ampersands(and, probably, some other characters as well).

Solution:
encode filename before performing request 