### PR TITLE
Reguess Mimtypes on Remote BLOBs

### DIFF
--- a/ckanext/cloudstorage/cli.py
+++ b/ckanext/cloudstorage/cli.py
@@ -83,3 +83,16 @@ def list_missing_uploads(output):
 def list_linked_uploads(output):
     """Lists uploads in the storage container that do match to a resource."""
     utils.list_linked_uploads(output)
+
+
+@cloudstorage.command()
+@click.option(
+    "-r",
+    "--resource_id",
+    default=None,
+    help="A single resource ID to reguess the mimetype for.",
+)
+@click.option('-v', '--verbose', is_flag=True, default=False, help='Higher verbosity level.')
+def reguess_mimetypes(resource_id=None, verbose=False):
+    """Reguess mimtypes for all uploads."""
+    utils.reguess_mimetypes(resource_id, verbose)

--- a/ckanext/cloudstorage/commands.py
+++ b/ckanext/cloudstorage/commands.py
@@ -45,6 +45,10 @@ class PasterCommand(CkanCommand):
         super(PasterCommand, self).__init__(name)
         self.parser.add_option('-o', '--output', dest='output', action='store',
                                default=None, help='The output file path.')
+        self.parser.add_option('-r', '--resource_id', dest='resource_id', action='store',
+                               default=None, help='A single resource ID to reguess the mimetype for.')
+        self.parser.add_option('-v', '--verbose', dest='verbose', action='store_true',
+                               default=False, help='Higher verbosity level.')
 
     def command(self):
         self._load_config()
@@ -66,6 +70,8 @@ class PasterCommand(CkanCommand):
             _list_missing_uploads(self.options.output)
         elif args['list-linked-uploads']:
             _list_linked_uploads(self.options.output)
+        elif args['reguess-mimetypes']:
+            _reguess_mimetypes(self.options.resource_id, self.options.verbose)
 
 
 def _migrate(args):
@@ -104,3 +110,8 @@ def _list_missing_uploads(output_path):
 def _list_linked_uploads(output_path):
     # type: (str|None) -> None
     utils.list_linked_uploads(output_path)
+
+
+def _reguess_mimetypes(resource_id, verbose):
+    # type: (str|None, bool) -> None
+    utils.reguess_mimetypes(resource_id, verbose)

--- a/ckanext/cloudstorage/storage.py
+++ b/ckanext/cloudstorage/storage.py
@@ -327,7 +327,7 @@ class ResourceCloudStorage(CloudStorage):
                 if self.guess_mimetype:
                     content_type, _ = mimetypes.guess_type(self.filename)
                     if content_type:
-                        blob_client.set_http_headers(ContentSettings(content_type=mimetypes))
+                        blob_client.set_http_headers(ContentSettings(content_type=content_type))
                 return stream.tell()
 
             else:
@@ -392,7 +392,7 @@ class ResourceCloudStorage(CloudStorage):
         # shared access link instead of simply redirecting to the file.
         if self.can_use_advanced_azure and self.use_secure_urls:
             from azure.storage.blob import BlobClient, BlobSasPermissions, BlobServiceClient, generate_blob_sas
-            
+
             svc_client = BlobServiceClient.from_connection_string(self.connection_link)
             container_client = svc_client.get_container_client(self.container_name)
             blob_client = container_client.get_blob_client(path)
@@ -409,7 +409,7 @@ class ResourceCloudStorage(CloudStorage):
                                     container_name=blob_client.container_name,
                                     blob_name=blob_client.blob_name,
                                     credential=sas_token)
-            
+
             # The url from blob_client above actually generate the url for download
             # but the file path is mixed with the filename e.g
             # we want to download `example.csv` but the url generate this
@@ -421,7 +421,7 @@ class ResourceCloudStorage(CloudStorage):
                 path,
                 sas_token
             )
-            
+
             return url
 
         elif self.can_use_advanced_aws and self.use_secure_urls:

--- a/ckanext/cloudstorage/storage.py
+++ b/ckanext/cloudstorage/storage.py
@@ -326,8 +326,9 @@ class ResourceCloudStorage(CloudStorage):
                 blob_client.upload_blob(stream, overwrite=True)
                 if self.guess_mimetype:
                     content_type, _ = mimetypes.guess_type(self.filename)
-                    if content_type:
-                        blob_client.set_http_headers(ContentSettings(content_type=content_type))
+                    if not content_type:
+                        content_type = 'application/octet-stream'
+                    blob_client.set_http_headers(ContentSettings(content_type=content_type))
                 return stream.tell()
 
             else:

--- a/ckanext/cloudstorage/utils.py
+++ b/ckanext/cloudstorage/utils.py
@@ -439,9 +439,9 @@ def reguess_mimetypes(resource_id=None, verbose=False):
                 blob_client = container_client.get_blob_client(
                     uploader.path_from_filename(resource['id'], uploader.filename))
                 content_type, _ = mimetypes.guess_type(uploader.filename)
-                if content_type:
-                    #content_disposition
-                    blob_client.set_http_headers(ContentSettings(content_type=content_type))
+                if not content_type:
+                    content_type = 'application/octet-stream'
+                blob_client.set_http_headers(ContentSettings(content_type=content_type))
                 if verbose:
                     click.echo(u'Reguessed mimetype successfully for resource {1}.'.format(resource_id))
                 success += 1

--- a/ckanext/cloudstorage/views/resource_download.py
+++ b/ckanext/cloudstorage/views/resource_download.py
@@ -1,6 +1,7 @@
 import os.path
 
-from ckan.plugins.toolkit import c, _
+from ckan.plugins.toolkit import c, _, request
+import mimetypes
 from ckan import logic, model
 from ckan.lib import base, uploader
 import ckan.lib.helpers as h
@@ -48,9 +49,11 @@ def resource_download(id, resource_id, filename= None):
     # if the client requests with a Content-Type header (e.g. Text preview)
     # we have to add the header to the signature
     try:
-        content_type = getattr(c.pylons.request, "content_type", None)
+        content_type = getattr(request, "content_type", None)
     except AttributeError:
         content_type = None
+    if not content_type:
+        content_type, _ = mimetypes.guess_type(filename)
     uploaded_url = upload.get_url_from_filename(resource['id'], filename,
                                                 content_type=content_type)
 
@@ -58,9 +61,9 @@ def resource_download(id, resource_id, filename= None):
     # provider being down.
     if uploaded_url is None:
         base.abort(404, _('No download is available'))
-    
+
     return  h.redirect_to(uploaded_url)
-    
+
 
 
 resource_blueprint.add_url_rule(


### PR DESCRIPTION
feat(cli): command to reguess mimetypes on remote blobs;

- Fixed mimetype guessing when uploading.
- Added cli utility to reguess resource formats onto the remote blobs.