### PR TITLE
Allow Context for Get Path

### DIFF
--- a/ckanext/cloudstorage/storage.py
+++ b/ckanext/cloudstorage/storage.py
@@ -298,8 +298,9 @@ class ResourceCloudStorage(CloudStorage):
             munge.munge_filename(filename)
         )
 
-    def get_path(self, resource_id):
-        resource = get_action('resource_show')({}, {'id': resource_id})
+    def get_path(self, resource_id, context={}):
+        # adds context parameter to allow for private resources (canada fork only)
+        resource = get_action('resource_show')(context, {'id': resource_id})
         filename = resource['url'].rsplit('/', 1)[-1]
 
         return self.get_url_from_filename(resource_id, filename)

--- a/ckanext/cloudstorage/storage.py
+++ b/ckanext/cloudstorage/storage.py
@@ -298,9 +298,12 @@ class ResourceCloudStorage(CloudStorage):
             munge.munge_filename(filename)
         )
 
-    def get_path(self, resource_id, context={}):
-        # adds context parameter to allow for private resources (canada fork only)
-        resource = get_action('resource_show')(context, {'id': resource_id})
+    def get_path(self, resource_id):
+        # at this point, any auth should be done already as you
+        # have to pass a Resource object to even get the uploader class (canada fork only)
+        #TODO: upstream contribution??
+        user = get_action('get_site_user')({'ignore_auth': True}, {})
+        resource = get_action('resource_show')({"user": user['name']}, {'id': resource_id})
         filename = resource['url'].rsplit('/', 1)[-1]
 
         return self.get_url_from_filename(resource_id, filename)


### PR DESCRIPTION
feat(dev): added context to get path;

- Add `context` method paramter to `get_path` to allow for private resources.

Required for: https://github.com/open-data/ckanext-xloader/pull/11